### PR TITLE
Add --notls support to wallet rpc server

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -90,15 +90,18 @@ func walletMain() error {
 
 	go func() {
 		// Read CA certs and create the RPC client.
-		certs, err := ioutil.ReadFile(cfg.CAFile)
-		if err != nil {
-			log.Warnf("Cannot open CA file: %v", err)
-			// If there's an error reading the CA file, continue
-			// with nil certs and without the client connection
-			certs = nil
+		var certs []byte
+		if !cfg.DisableClientTLS {
+			certs, err = ioutil.ReadFile(cfg.CAFile)
+			if err != nil {
+				log.Warnf("Cannot open CA file: %v", err)
+				// If there's an error reading the CA file, continue
+				// with nil certs and without the client connection
+				certs = nil
+			}
 		}
 		rpcc, err := chain.NewClient(activeNet.Params, cfg.RPCConnect,
-			cfg.BtcdUsername, cfg.BtcdPassword, certs)
+			cfg.BtcdUsername, cfg.BtcdPassword, certs, cfg.DisableClientTLS)
 		if err != nil {
 			log.Errorf("Cannot create chain server RPC client: %v", err)
 			return

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -51,7 +51,7 @@ type Client struct {
 	quitMtx sync.Mutex
 }
 
-func NewClient(net *btcnet.Params, connect, user, pass string, certs []byte) (*Client, error) {
+func NewClient(net *btcnet.Params, connect, user, pass string, certs []byte, disableTLS bool) (*Client, error) {
 	client := Client{
 		netParams:           net,
 		enqueueNotification: make(chan interface{}),
@@ -76,6 +76,7 @@ func NewClient(net *btcnet.Params, connect, user, pass string, certs []byte) (*C
 		Pass:                pass,
 		Certificates:        certs,
 		DisableConnectOnNew: true,
+		DisableTLS:          disableTLS,
 	}
 	c, err := btcrpcclient.New(&conf, &ntfnCallbacks)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -69,6 +69,7 @@ type config struct {
 	RPCKey           string   `long:"rpckey" description:"File containing the certificate key"`
 	RPCMaxClients    int64    `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
 	RPCMaxWebsockets int64    `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
+	DisableServerTLS bool     `long:"noservertls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
 	MainNet          bool     `long:"mainnet" description:"Use the main Bitcoin network (default testnet3)"`
 	SimNet           bool     `long:"simnet" description:"Use the simulation test network (default testnet3)"`
 	KeypoolSize      uint     `short:"k" long:"keypoolsize" description:"DEPRECATED -- Maximum number of addresses in keypool"`
@@ -265,9 +266,11 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Show the version and exit if the version flag was specified.
+	funcName := "loadConfig"
+	appName := filepath.Base(os.Args[0])
+	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		appName := filepath.Base(os.Args[0])
-		appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 		fmt.Println(appName, "version", version())
 		os.Exit(0)
 	}
@@ -363,6 +366,11 @@ func loadConfig() (*config, []string, error) {
 	// Add default port to connect flag if missing.
 	cfg.RPCConnect = normalizeAddress(cfg.RPCConnect, activeNet.btcdPort)
 
+	localhostListeners := map[string]struct{}{
+		"localhost": struct{}{},
+		"127.0.0.1": struct{}{},
+		"::1":       struct{}{},
+	}
 	// If CAFile is unset, choose either the copy or local btcd cert.
 	if cfg.CAFile == "" {
 		cfg.CAFile = filepath.Join(cfg.DataDir, defaultCAFilename)
@@ -405,6 +413,31 @@ func loadConfig() (*config, []string, error) {
 	// duplicate addresses.
 	cfg.SvrListeners = normalizeAddresses(cfg.SvrListeners,
 		activeNet.svrPort)
+
+	// Only allow server TLS to be disabled if the RPC is bound to localhost
+	// addresses.
+	if cfg.DisableServerTLS {
+		for _, addr := range cfg.SvrListeners {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				str := "%s: RPC listen interface '%s' is " +
+					"invalid: %v"
+				err := fmt.Errorf(str, funcName, addr, err)
+				fmt.Fprintln(os.Stderr, err)
+				fmt.Fprintln(os.Stderr, usageMessage)
+				return nil, nil, err
+			}
+			if _, ok := localhostListeners[host]; !ok {
+				str := "%s: the --noservertls option may not be used " +
+					"when binding RPC to non localhost " +
+					"addresses: %s"
+				err := fmt.Errorf(str, funcName, addr)
+				fmt.Fprintln(os.Stderr, err)
+				fmt.Fprintln(os.Stderr, usageMessage)
+				return nil, nil, err
+			}
+		}
+	}
 
 	// Expand environment variable and leading ~ for filepaths.
 	cfg.CAFile = cleanAndExpandPath(cfg.CAFile)


### PR DESCRIPTION
Refs #157 

Added two config params:

* `DisableServerTLS` `--noservertls` This disables TLS for the wallet RPC server and is localhost only
* `DisableClientTLS`  `--noclientts` This disables TLS when connecting to RPC server and is also localhost only. There's a risk of leaking sensitive data when switching between localhost and remote btcd servers so I think it's better to prevent that and have the same non-localhost checks for this too.

